### PR TITLE
Bug fix/stronghold 5 correct backup_ids hash

### DIFF
--- a/lib/stronghold/client.rb
+++ b/lib/stronghold/client.rb
@@ -45,7 +45,7 @@ module Stronghold
       backup_ids = {}
       description = archive_description.nil? ? file_path : "#{archive_description}"
       archive_id = create_archive(vault, file_path, description)
-      backup_ids[description] = archive_id
+      backup_ids[archive_id] = description
       return backup_ids
     end
 

--- a/lib/stronghold/version.rb
+++ b/lib/stronghold/version.rb
@@ -1,3 +1,3 @@
 module Stronghold
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
Addresses issue #5 "Client#create_backup method reverses return key/value pair in returned hash"; also, increments to v0.2.1